### PR TITLE
Updates for September 25, 2017 service release

### DIFF
--- a/case-studies.md
+++ b/case-studies.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-08-11"
+lastupdated: "2017-09-19"
 
 ---
 
@@ -19,7 +19,7 @@ lastupdated: "2017-08-11"
 
 # Case studies
 
-Read these case studies to get inspiration for what you can do with the {{site.data.keyword.toneanalyzerfull}} service. The studies describe the correlation between reported tones and expected outcomes. For most studies, IBM measured correlation as a number between 0 and 1, with 1 being a perfect correlation and 0 being no correlation.
+Read these case studies to get inspiration for what you can do with the {{site.data.keyword.toneanalyzerfull}} service. The studies describe the correlation between reported tones and expected outcomes. Correlation can be positive or negative and has a range of -1.0 to 1.0.
 {: shortdesc}
 
 ## Predicting customer satisfaction in support forums
@@ -42,8 +42,6 @@ The service can predict Kudos with 66-percent accuracy. IBM found the following 
 
 -   The more confident a response is, the more likely it is to earn Kudos (correlation of 0.23 between a high-value score on confidence and Kudos).
 -   The more tentative a response is, the less likely it is to earn Kudos (negative correlation of -0.27 between a high-value score on tentative and Kudos).
--   The more open a response is, the more likely it is to earn Kudos (correlation of 0.10 between a high-value score on openness and Kudos).
--   The more organized, thoughtful, and thorough a response is, the more likely it is to earn Kudos (correlation of 0.10 between a high-value score on conscientiousness and Kudos).
 
 ## Predicting customer satisfaction in Twitter responses
 
@@ -63,16 +61,9 @@ Validate whether the tone of the conversations between the agent and the custome
 
 ### Results
 
-The service can predict customer satisfaction from the tone of the response with 67-percent accuracy. IBM identified the following correlations between the tone of customer service tweets and whether the client was satisfied with the response:
+The service can predict customer satisfaction from the tone of the response with 67-percent accuracy. IBM discovered the following correlation between the tone of customer tweets and whether the customer was satisfied with the response:
 
--   Customer support representatives who act disgusted in their tweets are less likely to satisfy the customer (negative correlation of -0.155 between a high-value score on disgust in a customer service tweet and customer satisfaction).
--   Customer support representatives who seem frustrated, angry, stressed, or insecure are less likely to satisfy the customer (negative correlation of -0.186 between a high-value score on emotional range in a customer service tweet and customer satisfaction).
-
-IBM discovered the following correlations between the tone of customer tweets and whether the customer was satisfied with the response:
-
--   The angrier customers are, the less likely they are to be satisfied with the response (negative correlation of -0.198 between a high-value score on anger in a customer tweet and customer satisfaction).
--   The more disgusted customers are, the less likely they are to be satisfied with the response (negative correlation of -0.184 between a high-value score on disgust in a customer tweet and customer satisfaction).
--   The more organized, thoughtful, and thorough customers' tweets are, the more likely they are to be satisfied with the response (correlation of 0.177 between a high-value score on conscientiousness in a customer tweet and customer satisfaction).
+-   The angrier that customers are, the less likely they are to be satisfied with the response (negative correlation of -0.198 between a high-value score on anger in a customer tweet and customer satisfaction).
 
 ## Predicting TED Talk applause
 
@@ -95,14 +86,9 @@ Sentences that received applause were already tagged in the data set.
 
 The service can predict applause with 75-percent accuracy. IBM found the following correlations between the tone of each set of sentences and whether those sentences received applause:
 
--   The more disgusted a speaker is, the less likely they are to receive applause (negative correlation of -0.066 between a high-value score on disgust and applause).
 -   The more sadness a speaker expresses, the less likely they are to receive applause (negative correlation of -0.055 between a high-value score on sadness and applause).
 -   The more emotionless or impersonal a speaker seems, the less likely they are to receive applause (negative correlation of -0.29 between a high-value score on analytical and applause).
 -   The more joyful, contented, and satisfied a speaker seems, the more likely they are to receive applause (correlation of 0.21 between a high-value score on joy and applause).
--   The more organized, thoughtful, and thorough a speaker seems, the more likely they are to receive applause (correlation of 0.0964 between a high-value score on conscientiousness and applause).
--   The more engaging, sociable, and outgoing a speaker seems, the more likely they are to receive applause (correlation of 0.0942 between a high-value score on extraversion and applause).
--   The more caring, sympathetic, and trustworthy a speaker seems, the more likely they are to receive applause (correlation of 0.068 between a high-value score on agreeableness and applause).
--   The more concerned, passionate, and fierce a speaker seems, the more likely they are to receive applause (correlation of 0.064 between a high-value score on emotional range and applause).
 
 ## Predicting Twitter retweets and likes
 
@@ -120,17 +106,7 @@ Find correlations between the tone of a tweet and whether that tweet is liked or
 
 ### Results
 
-IBM found the following correlations between the tone of a tweet and whether it is liked:
-
--   The more imaginative, open to change, or emotionally aware a tweet seems, the more likely it is to be liked (correlation of 0.02 between a high-value score on openness and likes).
--   The more organized, thoughtful, or thorough a tweet seems, the more likely it is to be liked (correlation of 0.03 between a high-value score on consciousness and likes).
--   The angrier, more stressed, or impulsive a tweet seems, the less likely it is to be retweeted (negative correlation of -0.02 between a high-value score on emotional range and likes).
-
-IBM found the following correlations between the tone of a tweet and whether it is retweeted:
-
--   The more imaginative, open to change, or emotionally aware a tweet seems, the more likely it is to be retweeted (correlation of 0.05 between a high-value score on openness and retweets).
--   The more organized, thoughtful, or thorough a tweet seems, the more likely it is to be retweeted (correlation of 0.03 between a high-value score on consciousness and retweets).
--   The angrier, more stressed, or impulsive a tweet seems, the less likely it is to be retweeted (negative correlation of -0.033 between a high-value score on emotional range and retweets).
+IBM found correlations between the tone of a tweet and whether it is liked, and  between the tone of a tweet and whether it is retweeted.
 
 ## Predicting online dating matches
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-08-11"
+lastupdated: "2017-09-19"
 
 ---
 
@@ -39,10 +39,10 @@ If you already know the credentials for your {{site.data.keyword.toneanalyzersho
 ## Step 2: Use the general purpose endpoint via the POST request method
 {: #generalPurposePost}
 
-The following commands call the `POST /v3/tone` method to analyze the contents of the file `tone.json`. The file includes a single paragraph of plain text written by one person. The examples demonstrate various uses of the method's `tones` and `sentences` query parameters.
+The following commands call the `POST /v3/tone` method to analyze the contents of the file `tone.json`. The file includes a single paragraph of plain text written by one person. The examples demonstrate the method's `sentences` query parameters.
 
 1.  Download the sample file <a target="_blank" href="https://watson-developer-cloud.github.io/doc-tutorial-downloads/tone-analyzer/tone.json" download="tone.json">tone.json <img src="../../icons/launch-glyph.svg" alt="External link icon" title="External link icon" class="style-scope doc-content"></a>.
-1.  Issue the following command to analyze the input for all available tones: `emotion`, `language`, and `social`. The command analyzes the tones of the overall content and of each individual sentence.
+1.  Issue the following command to analyze the tone of the overall content and of each individual sentence.
     -   Replace `{username}` and `{password}` with your service credentials from the previous step.
     -   Modify `{path_to_file}` to specify the location of the `tone.json` file.
 
@@ -50,34 +50,17 @@ The following commands call the `POST /v3/tone` method to analyze the contents o
     curl -X POST --user "{username}":"{password}" \
     --header "Content-Type: application/json" \
     --data-binary @{path_to_file}tone.json \
-    "https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2016-05-19"
+    "https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2017-09-21"
     ```
     {: pre}
 
-1.  Issue the following command to limit the results to only the `emotion` tone by using the `tones` parameter. The command analyzes the emotional tone of the overall content and of each individual sentence.
-    -   Replace `{username}` and `{password}` with your service credentials.
-    -   Modify `{path_to_file}` to specify the location of the `tone.json` file.
+1.  Issue the following command to analyze the tone of the overall content only by setting the `sentences` parameter to `false`.
 
     ```bash
     curl -X POST --user "{username}":"{password}" \
     --header "Content-Type: application/json" \
     --data-binary @{path_to_file}tone.json \
-    "https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2016-05-19&tones=emotion"
-    ```
-    {: pre}
-
-    You can set the `tones` parameter to any combination of `emotion`, `language`, and `social`; for example, `tones=emotion,social`.
-    {: tip}
-
-1.  Issue the following command to analyze all available tones for the overall content only by setting the `sentences` parameter to `false`.
-    -   Replace `{username}` and `{password}` with your service credentials.
-    -   Modify `{path_to_file}` to specify the location of the `tone.json` file.
-
-    ```bash
-    curl -X POST --user "{username}":"{password}" \
-    --header "Content-Type: application/json" \
-    --data-binary @{path_to_file}tone.json \
-    "https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2016-05-19&sentences=false" \
+    "https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2017-09-21&sentences=false" \
     ```
     {: pre}
 
@@ -88,12 +71,11 @@ For an example of the method's output, see [Example response](/docs/services/ton
 
 The interface also offers a `GET /v3/tone` method. The `GET` method provides the same functionality and produces the same results as the `POST` method, but you use the method's `text` query parameter to specify the content to be analyzed. The method accepts only plain text input.
 
-1.  The following example specifies the text of the file `tone.json` via the `text` parameter; as shown, you must URL-encode the text. The command omits the `tones` and `sentences` parameters, so it returns the same output as the first `POST` example shown previously. (The example includes line breaks for readability; do not include them in an actual command.)
-    -   Replace `{username}` and `{password}` with your service credentials.
+1.  The following example specifies the text of the file `tone.json` via the `text` parameter; as shown, you must URL-encode the text. The command omits the `sentences` parameter, so it returns the same output as the first `POST` example shown previously. (The example includes line breaks for readability; do not include them in an actual command.)
 
     ```bash
     curl -X GET --user "{username}":"{password}" \
-    "https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2016-05-19
+    "https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2017-09-21
     &text=Team%2C%20I%20know%20that%20times%20are%20tough%21%20Product%20sales%20have
     %20been%20disappointing%20for%20the%20past%20three%20quarters.%20We%20have%20a%20
     competitive%20product%2C%20but%20we%20need%20to%20do%20a%20better%20job%20of%20
@@ -108,14 +90,12 @@ The following command calls the `POST /v3/tone_chat` method to analyze the conte
 
 1.  Download the sample file <a target="_blank" href="https://watson-developer-cloud.github.io/doc-tutorial-downloads/tone-analyzer/tone-chat.json" download="tone-chat.json">tone-chat.json <img src="../../icons/launch-glyph.svg" alt="External link icon" title="External link icon" class="style-scope doc-content"></a>.
 1.  Issue the following command to analyze the tone of the exchange in the sample file.
-    -   Replace `{username}` and `{password}` with your service credentials.
-    -   Modify `{path_to_file}` to specify the location of the `tone-chat.json` file.
 
     ```bash
     curl -X POST --user "{username}":"{password}" \
     --header "Content-Type: application/json" \
     --data-binary @{path_to_file}tone-chat.json \
-    "https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone_chat?version=2016-05-19"
+    "https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone_chat?version=2017-09-21"
     ```
     {: pre}
 
@@ -124,6 +104,6 @@ The service's response indicates the most prevalent tones detected for each utte
 ## Next steps
 
 -   For more information about the `/v3/tone` method, see [Using the general purpose endpoint](/docs/services/tone-analyzer/using-tone.html).
--   For more information about the `/v3/tone-chat` method, see [Using the customer engagement endpoint](/docs/services/tone-analyzer/using-tone-chat.html).
+-   For more information about the `/v3/tone_chat` method, see [Using the customer engagement endpoint](/docs/services/tone-analyzer/using-tone-chat.html).
 -   For detailed information about the methods of the service's interface, see the [API reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.ibm.com/watson/developercloud/tone-analyzer/api/v3/){: new_window}.
 -   Interact with the API in the [API explorer ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://watson-api-explorer.mybluemix.net/apis/tone-analyzer-v3){: new_window}.

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-08-15"
+lastupdated: "2017-09-25"
 
 ---
 
@@ -19,9 +19,9 @@ lastupdated: "2017-08-15"
 
 # About
 
-> **Service update:** *The {{site.data.keyword.toneanalyzershort}} service was updated on July 1, 2017. The customer engagement endpoint is now generally available (GA). Calls to the endpoint are now charged at the same rate as calls to the general purpose endpoint. For more information about this and all recent changes to the service, see the [Release notes](/docs/services/tone-analyzer/release-notes.html).*
+> **Service update:** *The {{site.data.keyword.toneanalyzershort}} service was updated on September 25, 2017. For the general purpose endpoint, both the request parameters and the response content changed; in addition, the endpoint no longer returns social tones or the disgust tone, and it now accepts French input. Input and throttling limits changed for both endpoints, as did the interface version. The service also now accepts partially correct input instead of returning an error for the overall request. For more information about these and other changes, see the [Release notes](/docs/services/tone-analyzer/release-notes.html).*
 
-The {{site.data.keyword.toneanalyzerfull}} service uses linguistic analysis to detect emotional, social, and language tones in written text. The service can analyze tone at both the document and sentence levels. You can use the service to understand how your written communications are perceived and then to improve the tone of your communications. Businesses can use the service to learn the tone of their customers' communications and to respond to each customer appropriately, or to understand and improve their customer conversations in general.
+The {{site.data.keyword.toneanalyzerfull}} service uses linguistic analysis to detect emotional and language tones in written text. The service can analyze tone at both the document and sentence levels. You can use the service to understand how your written communications are perceived and then to improve the tone of your communications. Businesses can use the service to learn the tone of their customers' communications and to respond to each customer appropriately, or to understand and improve their customer conversations in general.
 {: shortdesc}
 
 You submit JSON, plain text, or HTML input that contains your written content to the service. The service accepts up to 128 KB of text, which is about 1000 sentences. The service returns JSON results that report the tone of your input. You can use these results to improve the perception and effectiveness of your communications, ensuring that your writing conveys the tone and style that you want for your intended audience. The following diagram shows the basic flow of calls to the service.
@@ -51,13 +51,14 @@ Some interesting use cases of the service follow:
 
 -   *Social listening and audience monitoring:* Monitor social media to understand what customers are saying about your brand in real-time. For example, you might determine that your customers in Chicago are sad after the Bulls lost or happy during the Taste of Chicago festival. (General purpose endpoint)
 -   *Personalized marketing:* Determine whom to target with personalized messaging and when. For example, a travel company might target happy consumers with "treat yourself" messaging, sad consumers with "escape" messaging, and angry consumers with "relax" messaging. (General purpose endpoint)
--   *Chat bots:* Enable an automated agent to detect customer tones and, based on the tones identified, craft suitable responses. For example, you might respond to sadness with "I'm sorry you are upset about this problem" or to satisfaction with "I'm glad you are satisfied with our service." (Customer engagement endpoint)
+-   *Chat bots:* Enable an automated agent to detect customer tones and craft suitable responses. For example, you might respond to sadness with "I'm sorry you are upset about this problem" or to satisfaction with "I'm glad you are satisfied with our service." (Customer engagement endpoint)
 -   *Customer engagement monitoring and quality assurance:* Monitor the overall tone of agent and customer communications, detect anomalies, and highlight opportunities to train agents on how to better communicate. (Customer engagement endpoint)
 
-You can also use the {{site.data.keyword.toneanalyzershort}} service with additional {{site.data.keyword.ibmwatson_notm}} services, such as {{site.data.keyword.conversationfull}} or {{site.data.keyword.speechtotextfull}}, to analyze user input. For example, the [Conversation Food Coach ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://food-coach.mybluemix.net/){: new_window} application uses the {{site.data.keyword.conversationshort}} service to coach users to make healthy food choices based on their responses about the food that they eat. For more information, see this [Watson blog post ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://developer.ibm.com/watson/blog/2016/10/17/creating-a-compassionate-conversational-agent-using-watson-tone-analyzer-and-watson-conversation-services/){: new_window}.
+You can also use the {{site.data.keyword.toneanalyzershort}} service with additional {{site.data.keyword.ibmwatson_notm}} services, such as [{{site.data.keyword.conversationfull}}](https://console.bluemix.net/docs/services/conversation/index.html) or [{{site.data.keyword.speechtotextfull}}](https://console.bluemix.net/docs/services/speech-to-text/index.html), to analyze user input. For example, the [Conversation Food Coach ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://food-coach.mybluemix.net/){: new_window} application uses the {{site.data.keyword.conversationshort}} service to coach users to make healthy food choices based on their responses about the food that they eat. For more information, see this [Watson blog post ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://developer.ibm.com/watson/blog/2016/10/17/creating-a-compassionate-conversational-agent-using-watson-tone-analyzer-and-watson-conversation-services/){: new_window}.
 
 > **Note:** The {{site.data.keyword.toneanalyzershort}} service algorithmically calculates the tone of written text. It does not infer the personality characteristics of the author of the text. To obtain a personality portrait, see the [{{site.data.keyword.personalityinsightsfull}} service ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://console.bluemix.net/docs/services/personality-insights/index.html){: new_window}.
 
 ## Language support
+{: #languages}
 
-The {{site.data.keyword.toneanalyzershort}} service supports English text for analysis. French text is also supported in some instances of {{site.data.keyword.Bluemix_short}} Premium.
+The `/v3/tone` method can analyze content in English (`en`) and French (`fr`); the `/v3/tone_chat` method supports only English. Both methods can respond with localized content in a variety of languages. For more information, see [Using the general purpose endpoint](/docs/services/tone-analyzer/using-tone.html) and [Using the customer engagement endpoint](/docs/services/tone-analyzer/using-tone-chat.html).

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-08-11"
+lastupdated: "2017-09-25"
 
 ---
 
@@ -24,6 +24,33 @@ The following sections document the new features and changes that were included 
 
 > **Note:** The release notes now document the *service version* and *interface version* for each update. You specify the *interface version* with the `version` query parameter to use new features and functionality made available with that update. The service returns both versions with the `X-Service-Api-Version` response header.
 
+## 25 September 2017
+{: #September2017}
+
+**Service version:** `3.4.1`<br/> **Interface version:** `2017-09-21`
+
+-   The general purpose endpoint (the `/v3/tone` method) changed as follows:
+
+    -   Supports French (`fr`) input content in addition to English.
+    -   No longer returns social tones.
+    -   No longer returns `disgust` with the emotion tones.
+    -   Omits any tone whose score is less than `0.5`. This qualification matches the response of the `/v3/tone_chat` method.
+    - No longer returns tone categories (the `tone_categories` field) as part of its output. All tones whose values meet the qualifying threshold are returned as part of a single `tones` object. As before, tones are always returned for the full document and for each individual sentence by default.
+    - No longer accepts a `tones` query parameter to limit the output to specified tones. All qualifying tones are returned for every request. Including the parameter with a request does not cause an error, but it has no effect on the response.
+    - No longer returns `input_from` and `input_to` fields for individual sentences. In addition to the results of its analysis, the method now returns only an ID and the text of each sentence.
+
+-   The service now returns HTTP response code 200 instead of 400 for partially correct input in the following cases:
+
+    -   For the `/v3/tone` method, if you submit more than 128 KB or 1000 sentences of input content, the service returns a `warning` field as part of its response. The service analyzes the first 1000 sentences for document-level analysis and, as it does currently, only the first 100 sentences for sentence-level analysis. Earlier versions of the service returned response code 400 for the request if you exceeded either limit. Note also that the service now analyzes sentences that have fewer than three words.
+    -   For the `/v3/tone_chat` method, if you submit more than 50 utterances, the service returns a `warning` field for the overall content at the `utterances_tone` level of the response; it analyzes only the first 50 utterances. If you submit a single utterance that contains more than 500 characters, the service returns an `error` field for that utterance and does not analyze the utterance. Earlier versions of the service returned response code 400 if you exceeded either limit. Note that if all utterances of the input have more than 500 characters, the service still returns response code 400 for the request.
+
+-   The service now throttles the number of requests that it accepts from a single user. The service returns HTTP response code 429 *Too many requests* if it receives more than 600 requests per minute from an individual Bluemix username.
+
+-   The following changes apply to both the general purpose and customer engagement endpoints:
+
+    -   The interface version specified with the `version` parameter is `2017-09-21` to use the latest version of the service.
+    -   The documentation has been updated to note that the service can produce localized output in a variety of languages. Use the `Accept-Language` request header to specify the desired language.
+
 ## 6 July 2017
 {: #July2017b}
 
@@ -38,21 +65,22 @@ The service was updated for a small defect fix to the customer engagement endpoi
 
 The customer engagement endpoint of the {{site.data.keyword.toneanalyzershort}} service is now generally available (GA). All calls to the endpoint are now charged at the same rate as calls to the general purpose endpoint.
 
-## 8 May 2017
-{: #May2017}
-
-**Service version:** `3.3.4`<br/> **Interface version:** `2016-05-19`
-
-IBM updated the emotion tone and customer-care engagement tone score models by further expanding the training data set. The models now have greater precision on the benchmark data set.
-
 ## Older releases
 
+-   [8 May 2017](#May2017)
 -   [17 April 2017](#April2017)
 -   [15 March 2017](#March2017)
 -   [1 December 2016](#December2016)
 -   [18 October 2016](#October2016b)
 -   [3 October 2016](#October2016a)
 -   [19 May 2016](#May2016)
+
+### 8 May 2017
+{: #May2017}
+
+**Service version:** `3.3.4`<br/> **Interface version:** `2016-05-19`
+
+IBM updated the emotion tone and customer-care engagement tone score models by further expanding the training data set. The models now have greater precision on the benchmark data set.
 
 ### 17 April 2017
 {: #April2017}

--- a/science.md
+++ b/science.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-08-11"
+lastupdated: "2017-09-19"
 
 ---
 
@@ -19,14 +19,14 @@ lastupdated: "2017-08-11"
 
 # The science behind the service
 
-The {{site.data.keyword.toneanalyzerfull}} service is based on the theory of psycholinguistics, a field of research that explores the relationship between linguistic behavior and psychological theories. The service uses linguistic analysis and the correlation between the linguistic features of written text and emotional, social, and language tones to develop scores for each of these tone dimensions.
+The {{site.data.keyword.toneanalyzerfull}} service is based on the theory of psycholinguistics, a field of research that explores the relationship between linguistic behavior and psychological theories. The service uses linguistic analysis and the correlation between the linguistic features of written text and emotional and language tones to develop scores for each of these tone dimensions.
 {: shortdesc}
 
 Psycholinguistics researchers have worked to understand whether the words that we use in our day-to-day lives reflect who we are, how we feel, and how we think. After several decades of research in this area, it is now accepted in psychology, marketing, and other fields that language reflects more than just what we want to say. The frequency with which we use certain types of words can provide clues to personality, thinking style, social connections, and emotional states.
 
-For example, people exhibit various language tones in their daily communications: joyful or sad, open or conservative, analytical or informal ([Gou et al., 2014](/docs/services/tone-analyzer/references.html#bib-gou), and [Jian et al., 2014](/docs/services/tone-analyzer/references.html#bib-jian)). These tones can impact the perception of a person's online identity and the effectiveness of their communications in different contexts.
+For example, people exhibit various tones in their daily communications: joyful or sad, open or conservative, analytical or informal ([Gou et al., 2014](/docs/services/tone-analyzer/references.html#bib-gou), and [Jian et al., 2014](/docs/services/tone-analyzer/references.html#bib-jian)). These tones can impact the perception of a person's online identity and the effectiveness of their communications in different contexts.
 
-Moreover, in business email communications, people are likely to perceive negative emotions with greater intensity than they do positive emotions ([Byron, 2008](/docs/services/tone-analyzer/references.html#bib-byron)). The personality characteristics, such as openness and agreeableness, that people express in business communications also influence others' perceptions of their occupational proficiency ([Barrick & Mount 1991](/docs/services/tone-analyzer/references.html#bib-barrick)). And in social media, people present different online identities that impact the impression that others have of them ([DiMicco & Millen, 2007](/docs/services/tone-analyzer/references.html#bib-dimicco)).
+Moreover, in business email communications, people are likely to perceive negative emotions with greater intensity than they do positive emotions ([Byron, 2008](/docs/services/tone-analyzer/references.html#bib-byron)). And in social media, people present different online identities that impact the impression that others have of them ([DiMicco & Millen, 2007](/docs/services/tone-analyzer/references.html#bib-dimicco)).
 
 Many people naturally read a message and judge the tones conveyed by the sender. But can a computer detect the tones disclosed by a message accurately and automatically? This is one of the many challenging questions to which researchers in the artificial intelligence and cognitive sciences fields are seeking answers. First with the {{site.data.keyword.personalityinsightsshort}} service and now with the {{site.data.keyword.toneanalyzershort}} service, IBM is beginning to answer this question.
 
@@ -48,16 +48,16 @@ Most of these prior works are based on finding psychologically meaningful word c
 The general purpose endpoint analyzes written content for a set of tones that are applicable to a broad range of uses. The {{site.data.keyword.toneanalyzershort}} service computes a scorecard that includes the following tones:
 
 -   **Emotional tone** is derived from IBM's work on emotion analysis, which is an ensemble framework that infers emotions from a given text. To derive emotion scores from text, IBM use a stacked generalization-based ensemble framework; stacked generalization uses a high-level model to combine lower-level models to achieve greater predictive accuracy. Features such as n-grams (unigrams, bigrams, and trigrams), punctuation, emoticons, curse words, greetings (such as "hello," "hi," and "thanks"), and sentiment polarity are fed into machine-learning algorithms to classify emotion categories.
--   **Social tone** consists of the Big Five personality dimensions of openness, agreeableness, and conscientiousness. For more information about these Big Five characteristics, see [Personality models](http://www.ibm.com/watson/developercloud/doc/personality-insights/models.html) from the {{site.data.keyword.personalityinsightsshort}} service.
 -   **Language tone** is calculated from linguistic analysis based on learned features.
 
 ### Measuring the quality of the service
 
-IBM measured the quality of the {{site.data.keyword.toneanalyzershort}} service along each of the dimensions of tone mentioned in the previous section:
+IBM measured the quality of the {{site.data.keyword.toneanalyzershort}} service along the dimensions of tone mentioned in the previous section:
 
 -   *Emotional tone* categories were benchmarked against standard emotion data sets such as ISEAR and SEMEVAL. Results show that the average performance of the ensemble model (macro-average F1 score is around 41 percent and 68 percent, respectively, for the two data sets) is statistically better than the best reported accuracy of the state-of-the-art models (whose macro-average F1 scores are around 37 percent and 63 percent, respectively).
--   *Social tone* categories were tested against ground-truth data collected by administering personality surveys to more than 1500 people. The derived social scores were correlated with survey-based scores (p-value less than 0.05), with an average correlation coefficient of 0.33. The average Mean Absolute Error (MAE) between the inferred and actual scores was 0.12 for Big Five dimensions.
--   *Language tone* was evaluated with an in-depth study of more than two hundred thousand sentences collected from sources such as debate forums, speeches, and social media. Of these sentences, IBM randomly selected 1330 sentences for analytical tone and 1000 sentences each for confident and tentative tones. IBM then submitted these sentence to the {{site.data.keyword.toneanalyzershort}} service and also asked humans to analyze them. For the human analysis, IBM used a crowd-sourcing platform called [CrowdFlower ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.crowdflower.com/){: new_window} to annotate the selected sentences with different labels. Only raters with approval ratings over 85 percent were allowed to participate in the annotation tasks. Five annotators labeled each sentence, and IBM used the most prevalent of the five annotated results to determine the final labels.
+-   *Language tone* was evaluated with an in-depth study of more than two hundred thousand sentences collected from sources such as debate forums, speeches, and social media. Of these sentences, IBM randomly selected 1330 sentences for analytical tone and 1000 sentences each for confident and tentative tones. IBM then submitted these sentence to the {{site.data.keyword.toneanalyzershort}} service and also asked humans to analyze them.
+
+    For the human analysis, IBM used a crowd-sourcing platform called [CrowdFlower ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.crowdflower.com/){: new_window} to annotate the selected sentences with different labels. Only raters with approval ratings over 85 percent were allowed to participate in the annotation tasks. Five annotators labeled each sentence, and IBM used the most prevalent of the five annotated results to determine the final labels.
     -   For *analytical tone*, humans labeled 915 of the 1330 sentences as analytical, 411 as non-analytical, and 4 as not understandable. By comparing the predicted label with these ground-truth labels, IBM found that its analytical tone detection received an F1 score of 0.7518.
     -   For *tentative tone*, humans labeled 292 of the 1000 sentences as tentative, 706 as non-tentative, and 2 as not understandable. By comparing the predicted label with the ground-truth labels, IBM found that its tentative tone detection received an F1 score of 0.6369.
     -   For *confident tone*, humans labeled 623 of the 1000 sentences as confident, 374 as non-confident, and 3 as not understandable. By comparing the predicted label with the ground-truth labels, IBM found that its confident tone detection received an F1 score of 0.7288.

--- a/using-tone-chat.md
+++ b/using-tone-chat.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-09-10"
+lastupdated: "2017-09-20"
 
 ---
 
@@ -19,18 +19,16 @@ lastupdated: "2017-09-10"
 
 # Using the customer engagement endpoint
 
-The {{site.data.keyword.toneanalyzershort}} customer engagement endpoint analyzes the tone of customer service and support conversations. It can help you better understand your interactions with customers and improve your communications in general or for specific customers.
+The {{site.data.keyword.toneanalyzershort}} customer engagement endpoint analyzes the tone of customer service and support conversations. It can help you better understand your interactions with customers and improve your communications in general or for specific customers. For detailed information about the interface, including the Node.js, Java, and Python SDKs that are available for calling the service, see the [API reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.ibm.com/watson/developercloud/tone-analyzer/api/v3/){: new_window}.
 {: shortdesc}
-
-For detailed information about the interface, including the Node.js, Java, and Python SDKs that are available for calling the service, see the [API reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.ibm.com/watson/developercloud/tone-analyzer/api/v3/){: new_window}. For information about the research behind the service, see [The science behind the service](/docs/services/tone-analyzer/science.html).
 
 ## Requesting a tone analysis
 {: #request}
 
-To analyze tone with the customer engagement endpoint, you call the `POST /v3/tone-chat` method with the following parameters.
+To analyze tone with the customer engagement endpoint, you call the `POST /v3/tone_chat` method with the following parameters.
 
 <table>
-  <caption>Table 1. Parameters of the <code>POST /v3/tone-chat</code>
+  <caption>Table 1. Parameters of the <code>POST /v3/tone_chat</code>
     method</caption>
   <tr>
     <th style="text-align:left; width:20%">Parameter</th>
@@ -53,25 +51,73 @@ To analyze tone with the customer engagement endpoint, you call the `POST /v3/to
     <td style="text-align:center">String</td>
     <td>
       The requested version of the interface as a date in the form
-      <code>YYYY-MM-DD</code>; for example, specify <code>2016-05-19</code>
-      for May 19, 2016. The parameter allows the service to update its
-      interface and response format for new versions without breaking
-      existing clients.
+      <code>YYYY-MM-DD</code>; for example, specify <code>2017-09-21</code>
+      for September 21, 2017.
+    </td>
+  </tr>
+  <tr>
+    <td><code>Accept-Language</code><br/><em>Optional</em></td>
+    <td style="text-align:center">Header</td>
+    <td style="text-align:center">String</td>
+    <td>
+      The desired language of the response:
+      <ul style="margin:0px 0px 0px 20px; padding:0px">
+        <li style="margin:0px; padding:0px">
+          ar (Arabic)
+        </li>
+        <li style="margin:0px; padding:0px">
+          de (German)
+        </li>
+        <li style="margin:0px; padding:0px">
+          en (English, the default)
+        </li>
+        <li style="margin:0px; padding:0px">
+          es (Spanish)
+        </li>
+        <li style="margin:0px; padding:0px">
+          fr (French)
+        </li>
+        <li style="margin:0px; padding:0px">
+          it (Italian)
+        </li>
+        <li style="margin:0px; padding:0px">
+          ja (Japanese)
+        </li>
+        <li style="margin:0px; padding:0px">
+          ko (Korean)
+        </li>
+        <li style="margin:0px; padding:0px">
+          pt-br (Brazilian Portuguese)
+        </li>
+        <li style="margin:0px; padding:0px">
+          zh-cn (Simplified Chinese)
+        </li>
+        <li style="margin:0px; padding:0px">
+          zh-tw (Traditional Chinese)
+        </li>
+      </ul>
     </td>
   </tr>
 </table>
 
-The following example cURL command calls the customer engagement endpoint with the input file <a target="_blank" href="https://watson-developer-cloud.github.io/doc-tutorial-downloads/tone-analyzer/tone-chat.json" download="tone-chat.json">tone-chat.json <img src="../../icons/launch-glyph.svg" alt="External link icon" title="External link icon" class="style-scope doc-content"></a> and a version of `2016-05-19`:
+If you submit more than 50 utterances, the service returns a `warning` field for the overall content at the `utterances_tone` level of its response; it analyzes only the first 50 utterances. If you submit a single utterance that contains more than 500 characters, the service returns an `error` field for that utterance and does not analyze the utterance. In both cases, the request still succeeds with HTTP response code 200.
+
+> **Note:** The service returns response code 400 if all utterances of the input have more than 500 characters.
+
+### Example request
+{: #exampleRequest}
+
+The following example cURL command calls the customer engagement endpoint with the input file <a target="_blank" href="https://watson-developer-cloud.github.io/doc-tutorial-downloads/tone-analyzer/tone-chat.json" download="tone-chat.json">tone-chat.json <img src="../../icons/launch-glyph.svg" alt="External link icon" title="External link icon" class="style-scope doc-content"></a> and a version of `2017-09-21`:
 
 ```bash
 curl -X POST --user "{username}":"{password}"
 --header "Content-Type: application/json"
 --data-binary @./tone-chat.json
-"https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone_chat?version=2016-05-19"
+"https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone_chat?version=2017-09-21"
 ```
 {: pre}
 
-### Specifying JSON input
+## Specifying JSON input
 {: #JSONrequest}
 
 You pass the method a JSON `ToneChatInput` object with the following format. The `utterances` field provides an array of `utterance` objects, where `text` is a required string that provides an utterance contributed by a user to the conversation that is to be analyzed, and `user` is an optional string that identifies the user who contributed the utterance.
@@ -122,15 +168,15 @@ The service returns a JSON `UtteranceAnalyses` object that contains a single fie
 
 -   `utterance_id` (integer) provides the unique identifier of the utterance. The first utterance has ID 0, and the ID of each subsequent utterance is incremented by one.
 -   `utterance_text` (string) provides the text of the utterance.
--   `tones` is an array of `ToneChatScore` objects that provides results for any tone whose score is at least 0.5. The array is empty if the utterance has no tone with a score that meets this threshold.
+-   `tones` is an array of `ToneChatScore` objects that provides results for the dominant tones, those whose scores are at least 0.5. The array is empty if the utterance has no tone with a score that meets this threshold.
 
-Each `ToneChatScore` object provides the following information about one of the qualifying tones:
+Each `ToneChatScore` object provides the following information about a qualifying tone:
 
--   `score` (double) provides the score for the tone in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the utterance.
+-   `score` (double) is the score for the tone in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the utterance.
 -   `tone_id` (string) is the unique, non-localized identifier of the tone; for descriptions of the tones, see [Customer engagement tones](#tones).
 -   `tone_name` (string) is the user-visible, localized name of the tone.
 
-The following example shows the high-level structure of an `UtterancesAnalyses` object:
+The following example shows the structure of the `UtterancesAnalyses` object:
 
 ```javascript
 {
@@ -155,7 +201,7 @@ The following example shows the high-level structure of an `UtterancesAnalyses` 
 ### Example response
 {: #exampleResponse}
 
-The following output is returned for the example in [Requesting a tone analysis](#request). (The same output is returned for the example in the [Getting started tutorial](/docs/services/tone-analyzer/getting-started.html#customerEngagement).) All reported tones have a score of at least 0.5; those with a score of at least 0.75 are very likely to be perceived by participants in the conversation.
+The following output is returned for the [Example request](#exampleRequest). (The same output is returned for the example in the [Getting started tutorial](/docs/services/tone-analyzer/getting-started.html#customerEngagement).) All reported tones have a score of at least 0.5; those with a score of at least 0.75 are very likely to be perceived by participants in the conversation.
 
 ```javascript
 {

--- a/using-tone.md
+++ b/using-tone.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-09-10"
+lastupdated: "2017-09-21"
 
 ---
 
@@ -19,10 +19,8 @@ lastupdated: "2017-09-10"
 
 # Using the general purpose endpoint
 
-The {{site.data.keyword.toneanalyzershort}} general purpose endpoint analyzes the tone of written communications, from short email messages to longer documents. It can help you understand the emotional, social, and language tones of your communications.
+The {{site.data.keyword.toneanalyzershort}} general purpose endpoint analyzes the tone of written communications, from short email messages to longer documents. It can help you understand the emotional and language tones of your communications. For detailed information about the interface, including the Node.js, Java, and Python SDKs that are available for calling the service, see the [API reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.ibm.com/watson/developercloud/tone-analyzer/api/v3/){: new_window}.
 {: shortdesc}
-
-For detailed information about the interface, including the Node.js, Java, and Python SDKs that are available for calling the service, see the [API reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.ibm.com/watson/developercloud/tone-analyzer/api/v3/){: new_window}. For information about the research behind the service, see [The science behind the service](/docs/services/tone-analyzer/science.html).
 
 ## Requesting a tone analysis
 {: #request}
@@ -32,7 +30,7 @@ To analyze tone with the general purpose endpoint, you call one of the two versi
 -   The `POST /v3/tone` method accepts input content in JSON, plain text, or HTML format via the required body of the request. Use this version of the method for longer text or for text that you do not want to expose on the URL.
 -   The `GET /v3/tone` method accepts input content via its required `text` query parameter. Use this version of the method for simple text that is easily accommodated on the URL.
 
-The methods accept the following parameters. For input content, submit a maximum of 128 KB of content; sentences with fewer than three words cannot be analyzed.
+The methods accept the following parameters.
 
 <table>
   <caption>Table 1. Parameters of the <code>/v3/tone</code> methods</caption>
@@ -69,76 +67,124 @@ The methods accept the following parameters. For input content, submit a maximum
     <td style="text-align:center">String</td>
     <td>
       The content type of the request:
-      <ul style="margin-left:20px; padding:0px;">
-        <li style="margin:10px 0px; color:#404040; line-height:120%;">
+      <ul style="margin:0px 0px 0px 20px; padding:0px">
+        <li style="margin:0px; padding:0px">
           <code>text/plain</code> for plain text
         </li>
-        <li style="margin:10px 0px; color:#404040; line-height:120%;">
+        <li style="margin:0px; padding:0px">
             <code>text/html</code> for text in HTML (the service removes
             HTML tags and analyzes only the textual content)
         </li>
-        <li style="margin:10px 0px; color:#404040; line-height:120%;">
+        <li style="margin:0px; padding:0px">
           <code>application/json</code> for text in JSON format
         </li>
       </ul>
-    </td>
-  </tr>
-  <tr>
-    <td><code>tones</code><br/><em>Optional</em></td>
-    <td style="text-align:center">Query</td>
-    <td style="text-align:center">String[, String...] </td>
-    <td>
-      A comma-separated list of tones for which the service is to return
-      its analysis of the input; the indicated tones apply both to the full
-      document and to individual sentences of the document. You can specify
-      one or more of the following values:
-      <ul style="margin-left:20px; padding:0px;">
-        <li style="margin:10px 0px; color:#404040; line-height:120%;">
-          <code>emotion</code>
-        </li>
-        <li style="margin:10px 0px; color:#404040; line-height:120%;">
-          <code>social</code>
-        </li>
-        <li style="margin:10px 0px; color:#404040; line-height:120%;">
-          <code>language</code>
-        </li>
-      </ul>
-      Omit the parameter to request results for all three tones.
-    </td>
-  </tr>
-  <tr>
-    <td><code>sentences</code><br/><em>Optional</em></td>
-    <td style="text-align:center">Query</td>
-    <td style="text-align:center">String</td>
-    <td>
-      Indicates whether the service is to return an analysis of each
-      individual sentence in addition to its analysis of the full document.
-      If <code>true</code> (the default), the service returns results for
-      each sentence. The service returns results only for the first 100
-      sentences of the input.
+    <em>Omit for <code>GET</code> requests.</em>
     </td>
   </tr>
   <tr>
     <td><code>version</code><br/><em>Required</em></td>
     <td style="text-align:center">Query</td>
-    <td style="text-align:center">Boolean</td>
+    <td style="text-align:center">String</td>
     <td>
       The requested version of the response format as a date in the form
-      <code>YYYY-MM-DD</code>; for example, specify <code>2016-05-19</code>
-      for May 19, 2016. The parameter allows the service to update its
-      interface and response format for new versions without breaking
-      existing clients.
+      <code>YYYY-MM-DD</code>; for example, specify <code>2017-09-21</code>
+      for September 21, 2017.
+    </td>
+  </tr>
+  <tr>
+    <td><code>Content-Language</code><br/><em>Optional</em></td>
+    <td style="text-align:center">Header</td>
+    <td style="text-align:center">String</td>
+    <td>
+      The language of the input content:
+      <ul style="margin:0px 0px 0px 20px; padding:0px">
+        <li style="margin:0px; padding:0px">
+          <code>en</code> (English, the default)
+        </li>
+        <li style="margin:0px; padding:0px">
+            <code>fr</code> (French)
+        </li>
+      </ul>
+      Regional variants are treated as their parent language; for example,
+      <code>en-US</code> is interpreted as <code>en</code>. The input
+      content must match the specified language. Do not submit content
+      that contains both languages. You can use different languages for
+      the input and response.
+    </td>
+  </tr>
+  <tr>
+    <td><code>Accept-Language</code><br/><em>Optional</em></td>
+    <td style="text-align:center">Header</td>
+    <td style="text-align:center">String</td>
+    <td>
+      The desired language of the response:
+      <ul style="margin:0px 0px 0px 20px; padding:0px">
+        <li style="margin:0px; padding:0px">
+          ar (Arabic)
+        </li>
+        <li style="margin:0px; padding:0px">
+          de (German)
+        </li>
+        <li style="margin:0px; padding:0px">
+          en (English, the default)
+        </li>
+        <li style="margin:0px; padding:0px">
+          es (Spanish)
+        </li>
+        <li style="margin:0px; padding:0px">
+          fr (French)
+        </li>
+        <li style="margin:0px; padding:0px">
+          it (Italian)
+        </li>
+        <li style="margin:0px; padding:0px">
+          ja (Japanese)
+        </li>
+        <li style="margin:0px; padding:0px">
+          ko (Korean)
+        </li>
+        <li style="margin:0px; padding:0px">
+          pt-br (Brazilian Portuguese)
+        </li>
+        <li style="margin:0px; padding:0px">
+          zh-cn (Simplified Chinese)
+        </li>
+        <li style="margin:0px; padding:0px">
+          zh-tw (Traditional Chinese)
+        </li>
+      </ul>
+      For two-character arguments, regional variants are treated as their
+      parent language; for example, <code>en-US</code> is interpreted as
+      <code>en</code>. You can use different languages for the input and
+      response.
+    </td>
+  </tr>
+  <tr>
+    <td><code>sentences</code><br/><em>Optional</em></td>
+    <td style="text-align:center">Query</td>
+    <td style="text-align:center">Boolean</td>
+    <td>
+      Indicates whether the service is to return an analysis of each
+      individual sentence in addition to its analysis of the full document.
+      If <code>true</code> (the default), the service returns results for
+      each sentence.
     </td>
   </tr>
 </table>
 
-The following example cURL command uses the HTTP `POST` request method to call the general purpose endpoint with the input file <a target="_blank" href="https://watson-developer-cloud.github.io/doc-tutorial-downloads/tone-analyzer/tone.json" download="tone.json">tone.json <img src="../../icons/launch-glyph.svg" alt="External link icon" title="External link icon" class="style-scope doc-content"></a> and a version of `2016-05-19`. The example requests an analysis of all tones for both the full document and the individual sentences.
+Submit no more than 128 KB of total input content and no more than 1000 individual sentences. The service analyzes the first 1000 sentences for document-level analysis and only the first 100 sentences for sentence-level analysis. It returns a `warning` field as part of its response if you exceed either limit; the request still succeeds with HTTP response code 200.
+
+### Example requests
+{: #exampleRequests}
+
+The following example cURL command uses the HTTP `POST` request method to call the general purpose endpoint with the input file <a target="_blank" href="https://watson-developer-cloud.github.io/doc-tutorial-downloads/tone-analyzer/tone.json" download="tone.json">tone.json <img src="../../icons/launch-glyph.svg" alt="External link icon" title="External link icon" class="style-scope doc-content"></a> and a version of `2017-09-21`. The example requests an analysis for both the full document and the individual sentences.
 
 ```bash
 curl -X POST --user "{username}":"{password}"
 --header "Content-Type: application/json"
 --data-binary @./tone.json
-"https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2016-05-19"
+"https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2017-09-21"
 ```
 {: pre}
 
@@ -146,7 +192,7 @@ The following example command is equivalent to the previous example but uses the
 
 ```bash
 curl -X GET --user "{username}":"{password}"
-"https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2016-05-19&text=Team%2C%20I%20know%20that
+"https://gateway.watsonplatform.net/tone-analyzer/api/v3/tone?version=2017-09-21&text=Team%2C%20I%20know%20that
 %20times%20are%20tough%21%20Product%20sales%20have%20been%20disappointing%20for%20the%20past%20three%20quarters.
 %20We%20have%20a%20competitive%20product%2C%20but%20we%20need%20to%20do%20a%20better%20job%20of%20selling%20it%21"
 ```
@@ -199,22 +245,20 @@ The following example shows the contents of the <a target="_blank" href="https:/
 ## JSON response content
 {: #JSONresponse}
 
-The service returns a JSON `ToneAnalysis` object that always contains a `document_tone` field. This field contains a `DocumentAnalysis` object that provides the analysis of the full input document. It contains a single field, `tone_categories`, that contains an array of `ToneCategory` objects, one for each of the requested tones.
+The service returns a JSON `ToneAnalysis` object that always contains a `document_tone` field. This field contains a `DocumentAnalysis` object that provides the analysis of the full input document. It contains a single field, `tones`, that provides the results of the analysis for each qualifying tone of the document.
 
-If the `sentences` parameter of the request is set to `true`, the response also includes a `sentences_tone` field. This field contains an array of `SentenceAnalysis` objects, each of which provides the following information for a different sentence from the input content:
+If the `sentences` parameter of the request is omitted or set to `true`, the response also includes a `sentences_tone` field. This field contains an array of `SentenceAnalysis` objects, each of which provides the following information for a different sentence from the input content:
 
 -   `sentence_id` (integer) provides the unique identifier for the sentence. The first sentence has ID 0, and the ID of each subsequent sentence is incremented by one.
 -   `text` (string) provides the text of the sentence.
--   `input_from` (integer) identifies the offset of the first character of the sentence in the overall input content.
--   `input_to` (integer) identifies the offset of the last character of the sentence in the overall input content.
--   `tone_categories` contains an array of `ToneCategory` objects, one for each of the requested tones.
+-   `tones` provides the results of the analysis for each qualifying tone of the sentence.
 
 The following example shows the high-level structure of the `ToneAnalysis` object:
 
 ```javascript
 {
   "document_tone": {
-    "tone_categories": [
+    "tones": [
       . . .
     ]
   },
@@ -222,9 +266,7 @@ The following example shows the high-level structure of the `ToneAnalysis` objec
     {
       "sentence_id": {integer},
       "text": "{string}",
-      "input_from": {integer},
-      "input_to": {integer},
-      "tone_categories": [
+      "tones": [
         . . .
       ]
     },
@@ -234,85 +276,48 @@ The following example shows the high-level structure of the `ToneAnalysis` objec
 ```
 {: codeblock}
 
-### Tone category and score results
+### Tone and score results
 
-The `ToneCategory` objects that are returned for both document and sentence analyses have the following fields:
+The `tones` fields that are returned for both document- and sentence-level analyses contain an array of `ToneScore` objects that provides results for the dominant tones, those whose scores are at least 0.5. The array is empty if no tone has a score that meets this threshold. Each `ToneScore` object provides the following information about a qualifying tone:
 
--   `category_id` (string) is the unique, non-localized identifier of the category for the results: `emotion_tone`, `social_tone`, or `language_tone`. For both the document and its sentences, the service returns results only for the tones requested with the `sentences` query parameter.
--   `category_name` (string) is the user-visible, localized name of the category.
--   `tones` contains an array of `ToneScore` objects that provides the results for the tones of the category.
-
-The `ToneScore` objects that are returned for each tone category have the following fields:
-
--   `score` (double) provides the score for the tone in the range of 0 to 1.
--   `tone_id` (string) is the unique, non-localized identifier of the tone; for descriptions of the tones, [General purpose tones](#tones). The service returns scores for all tones of a category, regardless of their values.
+-   `score` (double) is the score for the tone in the range of 0.5 to 1. A score greater than 0.75 indicates a high likelihood that the tone is perceived in the content.
+-   `tone_id` (string) is the unique, non-localized identifier of the tone; for descriptions of the tones, see [General purpose tones](#tones).
 -   `tone_name` (string) is the user-visible, localized name of the tone.
 
-The following example shows the high-level structure of the `ToneCategory` object:
+The following example shows the structure of the `ToneScore` object:
 
 ```javascript
-"tone_categories": [
-  {
-    "category_id": "{string}",
-    "category_name": "{string}"
-    "tones": [
-      {
-        "score": {double},
-        "tone_id": "{string}",
-        "tone_name": "{string}"
-      },
-      . . .
-    ]
-  }
-  . . .
-]
+{
+  "tones": [
+    {
+      "score": {double},
+      "tone_id": "{string}",
+      "tone_name": "{string}"
+    },
+    . . .
+  ]
+}
 ```
 {: codeblock}
 
 ### Example response
 {: #exampleResponse}
 
-The following output is returned for the example in [Requesting a tone analysis](#request). (The same output is returned for the first example in [Getting started](/docs/services/tone-analyzer/getting-started.html).) The response includes results for the full document and for each individual sentence. To save space, the output omits many of the tones and scores.
+The following output is returned for the [Example requests](#exampleRequests). (The same output is returned for the first example in the [Getting started tutorial](/docs/services/tone-analyzer/getting-started.html).) The response includes results for the full document and for each individual sentence. All reported tones have a score of at least 0.5; those with a score of at least 0.75 are very likely to be perceived in the content.
 
 ```javascript
 {
   "document_tone": {
-    "tone_categories": [
+    "tones": [
       {
-        "tones": [
-          {
-            "score": 0.134622,
-            "tone_id": "anger",
-            "tone_name": "Anger"
-          },
-          . . .
-        ],
-        "category_id": "emotion_tone",
-        "category_name": "Emotion Tone"
+        "score": 0.6165,
+        "tone_id": "sadness",
+        "tone_name": "Sadness"
       },
       {
-        "tones": [
-          {
-            "score": 0.829888,
-            "tone_id": "analytical",
-            "tone_name": "Analytical"
-          },
-          . . .
-        ],
-        "category_id": "language_tone",
-        "category_name": "Language Tone"
-      },
-      {
-        "tones": [
-          {
-            "score": 0.230392,
-            "tone_id": "openness_big5",
-            "tone_name": "Openness"
-          },
-          . . .
-        ],
-        "category_id": "social_tone",
-        "category_name": "Social Tone"
+        "score": 0.829888,
+        "tone_id": "analytical",
+        "tone_name": "Analytical"
       }
     ]
   },
@@ -320,64 +325,39 @@ The following output is returned for the example in [Requesting a tone analysis]
     {
       "sentence_id": 0,
       "text": "Team, I know that times are tough!",
-      "input_from": 0,
-      "input_to": 34,
-      "tone_categories": [
+      "tones": [
         {
-          "tones": [
-            {
-              "score": 0.150882,
-              "tone_id": "anger",
-              "tone_name": "Anger"
-            },
-            . . .
-          ],
-          "category_id": "emotion_tone",
-          "category_name": "Emotion Tone"
-        },
-        . . .
+          "score": 0.801827,
+          "tone_id": "analytical",
+          "tone_name": "Analytical"
+        }
       ]
     },
     {
       "sentence_id": 1,
       "text": "Product sales have been disappointing for the past three quarters.",
-      "input_from": 35,
-      "input_to": 101,
-      "tone_categories": [
+      "tones": [
         {
-          "tones": [
-            {
-              "score": 0.106857,
-              "tone_id": "anger",
-              "tone_name": "Anger"
-            },
-            . . .
-          ],
-          "category_id": "emotion_tone",
-          "category_name": "Emotion Tone"
+          "score": 0.771241,
+          "tone_id": "sadness",
+          "tone_name": "Sadness"
         },
-        . . .
+        {
+          "score": 0.687768,
+          "tone_id": "analytical",
+          "tone_name": "Analytical"
+        }
       ]
     },
     {
       "sentence_id": 2,
       "text": "We have a competitive product, but we need to do a better job of selling it!",
-      "input_from": 102,
-      "input_to": 178,
-      "tone_categories": [
+      "tones": [
         {
-          "tones": [
-            {
-              "score": 0.094095,
-              "tone_id": "anger",
-              "tone_name": "Anger"
-            },
-            . . .
-          ],
-          "category_id": "emotion_tone",
-          "category_name": "Emotion Tone"
-        },
-        . . .
+          "score": 0.506763,
+          "tone_id": "analytical",
+          "tone_name": "Analytical"
+        }
       ]
     }
   ]
@@ -388,14 +368,10 @@ The following output is returned for the example in [Requesting a tone analysis]
 ## General purpose tones
 {: #tones}
 
-The following sections describe the emotion, social, and language tones that the service can return. For each tone, a score of less than 0.5 indicates that the emotion is unlikely to be perceived in the content. A score greater than 0.75 indicates a high likelihood that the tone will be perceived.
-
-### Emotion tones
-
-Emotion tones (ID `emotion_tone`) measure different types of emotions and feelings that people express.
+The following table describes the general purpose tones that the service can return. A tone whose score is less than 0.5 is omitted, indicating that the emotion is unlikely to be perceived in the content. A score greater than 0.75 indicates a high likelihood that the tone will be perceived.
 
 <table>
-  <caption>Table 2. Emotion tones</caption>
+  <caption>Table 2. General purpose tones</caption>
   <tr>
     <th style="text-align:left; vertical-align:bottom; width:20%">Tone / ID</th>
     <th style="text-align:left">Description</th>
@@ -406,14 +382,7 @@ Emotion tones (ID `emotion_tone`) measure different types of emotions and feelin
       Anger is evoked due to injustice, conflict, humiliation, negligence,
       or betrayal. If anger is active, the individual attacks the target,
       verbally or physically. If anger is passive, the person silently
-      sulks and feels tension and hostility.
-    </td>
-  </tr>
-  <tr>
-    <td>Disgust<br/><code>disgust</code></td>
-    <td>
-      Disgust is an emotional response of revulsion to something considered
-      offensive or unpleasant. The sensation refers to something revolting.
+      sulks and feels tension and hostility. (An emotional tone.)
     </td>
   </tr>
   <tr>
@@ -421,7 +390,7 @@ Emotion tones (ID `emotion_tone`) measure different types of emotions and feelin
     <td>
       Fear is a response to impending danger. It is a survival mechanism that
       is triggered as a reaction to some negative stimulus. Fear may be a mild
-      caution or an extreme phobia.
+      caution or an extreme phobia. (An emotional tone.)
     </td>
   </tr>
   <tr>
@@ -429,7 +398,7 @@ Emotion tones (ID `emotion_tone`) measure different types of emotions and feelin
     <td>
       Joy (or happiness) has shades of enjoyment, satisfaction, and pleasure.
       Joy brings a sense of well-being, inner peace, love, safety, and
-      contentment.
+      contentment. (An emotional tone.)
     </td>
   </tr>
   <tr>
@@ -437,129 +406,31 @@ Emotion tones (ID `emotion_tone`) measure different types of emotions and feelin
     <td>
       Sadness indicates a feeling of loss and disadvantage. When a person is
       quiet, less energetic, and withdrawn, it may be inferred that they feel
-      sadness.
+      sadness. (An emotional tone.)
     </td>
-  </tr>
-</table>
-
-### Social tones
-
-Social tones (ID `social_tone`) measure the social tendencies in people's writing. The tones are adopted from the Big Five personality model; for more information, see the [Personality models](http://www.ibm.com/watson/developercloud/doc/personality-insights/models.html) described for the {{site.data.keyword.personalityinsightsfull}} service.
-
-<table>
-  <caption>Table 3. Social tones</caption>
-  <tr>
-    <th style="text-align:left; vertical-align:bottom">Tone / ID</th>
-    <th style="text-align:left; vertical-align:bottom">Tone</th>
-    <th style="text-align:left; vertical-align:bottom">People with a score of &lt;0.5 are more likely to be perceived as...</th>
-    <th style="text-align:left; vertical-align:bottom">People with a score of &gt;0.75 are more likely to be perceived as...</th>
-  </tr>
-  <tr>
-    <td>Agreeableness<br/><code>agreeableness_big5</code></td>
-    <td>
-      The tendency to be compassionate and cooperative towards others
-    </td>
-    <td>
-      Selfish, uncaring, uncooperative, self-interested, confrontational,
-      skeptical, or arrogant
-    </td>
-    <td>
-      Caring, sympathetic, cooperative, compromising, trustworthy, or humble
-    </td>
-  </tr>
-  <tr>
-    <td>Conscientiousness<br/><code>conscientiousness_big5</code></td>
-    <td>
-      The tendency to act in an organized or thoughtful way
-    </td>
-    <td>
-      Spontaneous, laid-back, reckless, unmethodical, remiss, or disorganized
-    </td>
-    <td>
-      Disciplined, dutiful, achievement-striving, confident, driven, or
-      organized
-    </td>
-  </tr>
-  <tr>
-    <td>Emotional range<br/><code>emotional_range_big5</code></td>
-    <td>
-      The extent to which a person's emotions are sensitive to their
-      environment
-    </td>
-    <td>
-      Calm, bland, content, relaxed, unconcerned, or careful
-    </td>
-    <td>
-      Concerned, frustrated, angry, passionate, upset, stressed, insecure,
-      or impulsive
-    </td>
-  </tr>
-  <tr>
-    <td>Extraversion<br/><code>extraversion_big5</code></td>
-    <td>
-      The tendency to seek stimulation in the company of others
-    </td>
-    <td>
-      Independent, timid, introverted, restrained, boring, or dreary
-    </td>
-    <td>
-      Engaging, seeking attention, needy, assertive, outgoing, sociable,
-      cheerful, excitement-seeking, or busy
-    </td>
-  </tr>
-  <tr>
-    <td>Openness<br/><code>openness_big5</code></td>
-    <td>
-      The extent to which a person is open to experiencing a variety of
-      activities
-    </td>
-    <td>
-      No-nonsense, straightforward, blunt, or preferring tradition and the
-      obvious over the complex, ambiguous, and subtle
-    </td>
-    <td>
-      Intellectual, curious, emotionally aware, imaginative, willing to try
-      new things, appreciating beauty, or open to change
-    </td>
-  </tr>
-</table>
-
-### Language tones
-
-Language tones (ID `language_tone`) describe a person's perceived writing style. A score of less than 0.5 indicates that the content offered little or no evidence of the tone.
-
-<table>
-  <caption>Table 4. Language tones</caption>
-  <tr>
-    <th style="text-align:left; vertical-align:bottom; width:20%">Tone / ID</th>
-    <th style="text-align:left; vertical-align:bottom; width:40%">Description</th>
-    <th style="text-align:left">People with a score of &gt;0.75 are more likely to be perceived as...</th>
   </tr>
   <tr>
     <td>Analytical<br/><code>analytical</code></td>
     <td>
-      A person's reasoning and analytical attitude about things
-    </td>
-    <td>
-      Intellectual, rational, systematic, emotionless, or impersonal
+      An analytical tone indicates a person's reasoning and analytical attitude
+      about things. An analytical person might be perceived as intellectual,
+      rational, systematic, emotionless, or impersonal. (A language tone.)
     </td>
   </tr>
   <tr>
     <td>Confident<br/><code>confident</code></td>
     <td>
-      A person's degree of certainty
-    </td>
-    <td>
-      Assured, collected, hopeful, or egotistical
+      A confident tone indicates a person's degree of certainty. A confident
+      person might be perceived as assured, collected, hopeful, or egotistical.
+      (A language tone.)
     </td>
   </tr>
   <tr>
     <td>Tentative<br/><code>tentative</code></td>
     <td>
-      A person's degree of inhibition
-    </td>
-    <td>
-      Questionable, doubtful, or debatable
+      A tentative tone indicates a person's degree of inhibition. A tentative
+      person might be perceived as questionable, doubtful, or debatable. (A
+      language tone.)
     </td>
   </tr>
 </table>


### PR DESCRIPTION
- Service version: 3.4.1.
- Interface version: 2017-09-21.
- Add support for French input content for /v3/tone.
- Document support for localized response content for both /v3/tone and /v3/tone_chat.
- Remove all social tones for /v3/tone.
- Remove disgust from emotion tones for /v3/tone.
- Remove tone_categories field for /v3/tone.
- Remove tones query parameter for /v3/tone.
 - Remove input_from and input_to fields for for /v3/tone.
 - The /v3/tone method now returns only dominant tones, those with a score of at least 0.5 (matches /v3/tone_chat).
 - New throttling limit of 600 requests/minute for any user. Returns response code 429 if exceeded.
 - Returns response code 200 and includes warning/error fields for partially correct input. Includes new limits, fields, and descriptions.